### PR TITLE
Improve workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,29 +4,24 @@ on:
   push:
     branches:
     - main
+  pull_request:
 
 jobs:
   build-deploy:
     runs-on: ubuntu-18.04
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
     steps:
     - uses: actions/checkout@v2
 
     - name: setup node
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: '12.x'
-
-    # npm install の際にキャッシュを使うよう設定
-    - name: Cache dependencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        cache: 'npm'
 
     - name: install
-      run: npm install --frozen-lockfile
+      run: npm ci
 
     # Next.jsアプリをビルドする
     # プロジェクトルート直下に.nextディレクトリができる
@@ -39,16 +34,11 @@ jobs:
     - name: export
       run: npm run export
 
-    # しかしGitHub Pagesの仕様として_から始まるディレクトリが見えず404となる
-    # つまりHTMLからJSを読み込めない
-    # これを回避するために.nojekyllファイルをoutディレクトリに作る
-    - name: add nojekyll
-      run: touch ./out/.nojekyll
-
     # gh-pagesブランチにoutディレクトリの中身をプッシュする
     # gh-pagesブランチは自動的に作成される
     - name: deploy
       uses: peaceiris/actions-gh-pages@v3
+      if: ${{ github.ref == 'refs/heads/main' }}
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./out


### PR DESCRIPTION
- pull-request でビルドのテストをできるように(デプロイはスキップ)
- actions/setup-node を v1 から v2 へ更新。 actions/cache の代わりに `cache: npm` を使用
- `npm ci` を使用
- peaceiris/actions-gh-pages が追加してくれるので `.nojekyll` 追加 step を削除